### PR TITLE
README: Fix image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Kuiper is a specialized Debian-based Linux distribution designed specifically fo
 
 Whether you're prototyping with an ADI evaluation board, developing embedded applications, or building software-defined radio solutions, Kuiper gives you a solid foundation to start immediately without the complexity of manual system configuration.
 
-📖 **[Complete Documentation](https://analogdevicesinc.github.io/kuiper/)** | 📥 **[Pre-built Images](https://github.com/analogdevicesinc/kuiper/actions/workflows/kuiper2_0-build.yml)** | 🐛 **[Issues](https://github.com/analogdevicesinc/kuiper/issues)** | 💬 **[Community](https://ez.analog.com/linux-software-drivers)**
+📖 **[Complete Documentation](https://analogdevicesinc.github.io/kuiper/)** | 📥 **[Pre-built Images](https://github.com/analogdevicesinc/kuiper/actions/workflows/kuiper2_0-build.yml?query=branch:main)** | 🐛 **[Issues](https://github.com/analogdevicesinc/kuiper/issues)** | 💬 **[Community](https://ez.analog.com/linux-software-drivers)**
 
 ## Quick Start
 


### PR DESCRIPTION
Fix link to point towards Kuiper images built only on the main branch.

## PR Type
- [x] Bug fix (change that fixes an issue)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [x] I have updated the documentation (wiki pages, ReadMe etc)
