### PR TITLE
Docker images should be in cloudsmith

### DIFF
--- a/.github/workflows/docker-image-build.yml
+++ b/.github/workflows/docker-image-build.yml
@@ -7,6 +7,7 @@ jobs:
     permissions:
       packages: write
       contents: read
+      id-token: write
     strategy:
       matrix:
         kuiper_artifact: [kuiper_basic_32, kuiper_basic_64]
@@ -16,18 +17,19 @@ jobs:
             - kuiper_artifact: kuiper_basic_64
               arch: linux/arm64
     steps:
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
+      - name: Generate Cloudsmith OIDC Token
+        uses: cloudsmith-io/cloudsmith-cli-action@ad73fafb92e3e29a5166c529464c2df7658a608e # v3.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          oidc-namespace: adi
+          oidc-service-slug: ${{ secrets.CLOUDSMITH_USER }}
+          export-auth-token: true
 
-      - name: Log in to the GitHub Container registry
-        uses: docker/login-action@v1
+      - name: Docker login Cloudsmith
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.cloudsmith.io/adi/containers
+          username: ${{ secrets.CLOUDSMITH_USER }}
+          password: ${{ env.CLOUDSMITH_API_KEY }}
 
       - name: Checkout Dockerfile for image building
         uses: actions/checkout@v4
@@ -73,12 +75,11 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           push: true
           file: ci/Dockerfile
           context: .
           platforms: ${{ matrix.arch }}
           tags: |
-            aandrisa/${{ matrix.kuiper_artifact }}:latest
-            ghcr.io/analogdevicesinc/kuiper/${{ matrix.kuiper_artifact }}:latest
+            docker.cloudsmith.io/adi/containers/${{ matrix.kuiper_artifact }}:latest


### PR DESCRIPTION
As per analogdevicesinc requirements, docker images should not be in either ghcr nor private dockerhub accounts. Publishing them to cloudsmith.

The workflow run for the changes [here](https://github.com/analogdevicesinc/kuiper/actions/runs/33391694863)


## Pull Request Description

Please replace this with a detailed description and motivation of the changes.
You can tick the checkboxes below with an 'x' between square brackets or just check them after publishing the PR.
If this PR contains a breaking change, list dependent PRs and try to push all related PRs at the same time.

## PR Type
- [x] Bug fix (change that fixes an issue)
- [ ] New feature (change that adds new functionality)
- [ ] Breaking change (has dependencies in other repos or will cause CI to fail)

## PR Checklist
- [x] I have performed a self-review of the changes
- [ ] I have commented my code, at least hard-to-understand parts
- [ ] I have built Kuiper Linux image with the changes
- [ ] I have tested new image in hardware, on relevant boards
- [x] I have signed off all commits from this PR
- [ ] I have updated the documentation (wiki pages, ReadMe etc)
