### PR TITLE
.github/docs: dirhtml instead of html

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,13 +30,13 @@ jobs:
     - name: Build doc
       working-directory: docs
       run: |
-        make html SPHINXOPTS='-W --keep-going'
+        make dirhtml SPHINXOPTS='-W --keep-going'
 
     - name: Store the generated doc
       uses: actions/upload-artifact@v4
       with:
         name: html
-        path: docs/_build/html
+        path: docs/_build/dirhtml
 
   deploy-gh-pages:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To not require the .html, use Sphinx dirhtml suffix that wraps
non-index pages into subdirectories, for example:

  software/app/cli.rst -> software/app/cli/